### PR TITLE
Fix cURL Errror 60

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -25,7 +25,7 @@ https://github.com/XTLS/Xray-core/issues/91
 
 支持配置方式
 
-VLESS + TCP + TLS + Nginx + WebSocket
+- VLESS + TCP + TLS + Nginx + WebSocket
 
 ```
 wget -N --no-check-certificate -q -O install.sh "https://raw.githubusercontent.com/wulabing/Xray_onekey/nginx_forward/install.sh" && chmod +x install.sh && bash install.sh
@@ -35,9 +35,9 @@ wget -N --no-check-certificate -q -O install.sh "https://raw.githubusercontent.c
 
 支持配置方式
 
-VLESS + TCP + XTLS / TLS  + Nginx
+- VLESS + TCP + XTLS / TLS  + Nginx
 
-VLESS + TCP + XTLS / TLS  + Nginx 及 VLESS + TCP + TLS + Nginx + WebSocket 回落并存模式
+- VLESS + TCP + XTLS / TLS  + Nginx 及 VLESS + TCP + TLS + Nginx + WebSocket 回落并存模式
 
 ```
 wget -N --no-check-certificate -q -O install.sh "https://raw.githubusercontent.com/wulabing/Xray_onekey/main/install.sh" && chmod +x install.sh && bash install.sh

--- a/install.sh
+++ b/install.sh
@@ -95,7 +95,7 @@ function system_check() {
     INS="apt install -y"
     # 清除可能的遗留问题
     rm -f /etc/apt/sources.list.d/nginx.list
-    $INS lsb-release gnupg2
+    $INS lsb-release gnupg2 ca-certificates
 
     echo "deb http://nginx.org/packages/debian $(lsb_release -cs) nginx" >/etc/apt/sources.list.d/nginx.list
     curl -fsSL https://nginx.org/keys/nginx_signing.key | apt-key add -


### PR DESCRIPTION
- Install `ca-certificates` in advance to solve the problem that cURL reports error 60 when issuing Let's Encrypt certificates due to the expiration of `DST Root CA X3`.
- `README.MD` visual update.