### PR TITLE
修复搬瓦工机器上卡证书签发的问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,7 @@ function system_check() {
   if [[ "${ID}" == "centos" && ${VERSION_ID} -ge 7 ]]; then
     print_ok "当前系统为 Centos ${VERSION_ID} ${VERSION}"
     INS="yum install -y"
+    ${INS} wget
     wget -N -P /etc/yum.repos.d/ https://raw.githubusercontent.com/wulabing/Xray_onekey/${github_branch}/basic/nginx.repo
   elif [[ "${ID}" == "ol" ]]; then
     print_ok "当前系统为 Oracle Linux ${VERSION_ID} ${VERSION}"

--- a/install.sh
+++ b/install.sh
@@ -379,7 +379,7 @@ function acme() {
   sed -i "6a\\\troot $website_dir;" "$nginx_conf"
   systemctl restart nginx
 
-  if "$HOME"/.acme.sh/acme.sh --issue -d "${domain}" --webroot "$website_dir" -k ec-256 --force; then
+  if "$HOME"/.acme.sh/acme.sh --issue --insecure -d "${domain}" --webroot "$website_dir" -k ec-256 --force; then
     print_ok "SSL 证书生成成功"
     sleep 2
     if "$HOME"/.acme.sh/acme.sh --installcert -d "${domain}" --fullchainpath /ssl/xray.crt --keypath /ssl/xray.key --reloadcmd "systemctl restart xray" --ecc --force; then


### PR DESCRIPTION
两个修改：
### 1、添加安装wget的语句
如果有人通过下载脚本到本地后再执行，就会没装wget
这里加了一条安装wget的命令，如果已经装过则会跳过

### 2、修复搬瓦工机器上卡证书签发的问题
在acme()中添加"--insecure"
解决SSL 证书测试签发失败的问题
这个问题和之前tls-ws里的问题一样：https://github.com/wulabing/V2Ray_ws-tls_bash_onekey/issues/14

#### 已完成在搬瓦工软银线路机器测试